### PR TITLE
Feat/ssr cards

### DIFF
--- a/altrpnjs/app/Controllers/Http/AltrpRouting.ts
+++ b/altrpnjs/app/Controllers/Http/AltrpRouting.ts
@@ -425,8 +425,11 @@ window.altrp_dictionary = ${JSON.stringify(_content.dictionary)};
         /* ]]> */
 </script>`
       let all_styles = _all_styles
+      const cardsDataForSubstitution = this.getCardsDataForSubstitution(page_areas, datasources);
+
       content = mustache.render(content, {
         ...altrpContext,
+        ...cardsDataForSubstitution,
         dictionary,
         altrpContext,
         access_classes,
@@ -776,6 +779,37 @@ window.altrp_dictionary = ${JSON.stringify(_content.dictionary)};
     elementNames = _.uniq(elementNames)
 
     return elementNames;
+  }
+
+  private extractElements(name: string, areas: any[]) {
+    let result: any[] = [];
+
+    if (!areas.length) return result;
+
+    areas.forEach(area => {
+
+      //------ extracts children first from areas, than from area's descendants
+      const children = area?.template?.data?.children || area?.children || [];
+      if (children.length) {
+        result.push(...children.filter(child => child.name === name));
+          result.push(...this.extractElements(name, children));
+      }
+    })
+
+    return result;
+  }
+
+  private getCardsDataForSubstitution (pageAreas: string, datasources: object) {
+      const cardsWidgets = this.extractElements('cards', JSON.parse(pageAreas));
+      const cardsDataSources = cardsWidgets.map(widget =>({id: widget.id, dataSources: widget.settings.posts_datasource.replace('altrpdata.', '')}));
+      const cardsData: {id: string, data: object[] | undefined}[] = cardsDataSources.map(source => ({id: source.id, data: _.get(datasources, source.dataSources)}));
+      const cardsDataForSubstitution = cardsData ? cardsData.reduce((accum, data) => {
+      const dataItem = data.data ? data.data.reduce((accum, item, index) => {
+          return {...accum, ..._.mapKeys(item, (_, key) => `${key}${data.id}_${index}`)};
+        }, {}) : {};
+        return {...accum, ...dataItem};
+      }, {}) : {};
+      return cardsDataForSubstitution;
   }
 
   private async prepareContent(content: string,  { lang }): Promise<{content: string, dictionary: {  }}> {

--- a/altrpnjs/app/Generators/ModelGenerator.ts
+++ b/altrpnjs/app/Generators/ModelGenerator.ts
@@ -3,7 +3,7 @@ import app_path from "../../helpers/path/app_path";
 import Column from "App/Models/Column";
 import Table from "App/Models/Table";
 import Relationship from "App/Models/Relationship";
-import fs from 'fs'
+import fs from "fs";
 import BaseGenerator from "./BaseGenerator";
 import * as _ from "lodash";
 import ControllerGenerator from "./ControllerGenerator";
@@ -13,72 +13,77 @@ import clearRequireCache from "../../helpers/node-js/clearRequireCache";
 import Customizer from "App/Models/Customizer";
 
 export default class ModelGenerator extends BaseGenerator {
-
-  public static directory = app_path('/AltrpModels/')
-  public static template = app_path(`/altrp-templates/${isProd() ? 'prod' : 'dev'}/AltrpModel.stub`)
-  public static ext = isProd() ? '.js': '.ts'
-  private model: Model
-  private table: Table
-  private altrp_relationships: Relationship[] = []
-  private columns: Column[] = []
-
+  public static directory = app_path("/AltrpModels/");
+  public static template = app_path(
+    `/altrp-templates/${isProd() ? "prod" : "dev"}/AltrpModel.stub`
+  );
+  public static ext = isProd() ? ".js" : ".ts";
+  private model: Model;
+  private table: Table;
+  private altrp_relationships: Relationship[] = [];
+  private columns: Column[] = [];
 
   public async deleteFiles(model: Model): Promise<void> {
-    let fileName = this.getFilename(model)
+    let fileName = this.getFilename(model);
     if (fs.existsSync(ModelGenerator.directory + fileName)) {
       fs.rmSync(ModelGenerator.directory + fileName);
     }
-    fileName =`${model.name}Controller${ModelGenerator.ext}`
+    fileName = `${model.name}Controller${ModelGenerator.ext}`;
     if (fs.existsSync(ControllerGenerator.directory + fileName)) {
       fs.rmSync(ControllerGenerator.directory + fileName);
     }
-    return
+    return;
   }
-  getFilename(model):string{
-    let fileName = model.name + ModelGenerator.ext
-    return fileName
+  getFilename(model): string {
+    let fileName = model.name + ModelGenerator.ext;
+    return fileName;
   }
   public async run(model: Model) {
-    if(! model){
-      return
+    if (!model) {
+      return;
     }
     await model.load((loader) => {
-      loader.load('table', (table) => {
-        table.preload('columns', column=>{
-          column.preload('altrp_model')
-        })
-      })
-      loader.load('altrp_relationships', relation => {
-        relation.preload('altrp_target_model')
-        relation.preload('altrp_model')
-      })
-    })
+      loader.load("table", (table) => {
+        table.preload("columns", (column) => {
+          column.preload("altrp_model");
+        });
+      });
+      loader.load("altrp_relationships", (relation) => {
+        relation.preload("altrp_target_model");
+        relation.preload("altrp_model");
+      });
+    });
 
-    let custom = ''
-    let custom_end = ''
+    let custom = "";
+    let custom_end = "";
 
-
-    this.model = model
-    this.table = model.table
-    this.altrp_relationships = model.altrp_relationships
-    this.columns = this.table.columns
-    let fileName = this.getFilename(model)
+    this.model = model;
+    this.table = model.table;
+    this.altrp_relationships = model.altrp_relationships;
+    this.columns = this.table.columns;
+    let fileName = this.getFilename(model);
     if (!model.name) {
-      return
+      return;
     }
     if (fs.existsSync(ModelGenerator.directory + fileName)) {
-      let oldContent:string = fs.readFileSync(ModelGenerator.directory + fileName,  {encoding: 'utf8'})
-      if(oldContent){
-        custom = oldContent.match(/\/\/ CUSTOM_START([\s\S]+?)\/\/ CUSTOM_START/)?.pop() || ''
-        custom = custom.trim()
-        custom_end = oldContent.match(/\/\/ CUSTOM_END([\s\S]+?)\/\/ CUSTOM_END/)?.pop() || ''
-        custom_end = custom_end.trim()
+      let oldContent: string = fs.readFileSync(
+        ModelGenerator.directory + fileName,
+        { encoding: "utf8" }
+      );
+      if (oldContent) {
+        custom =
+          oldContent
+            .match(/\/\/ CUSTOM_START([\s\S]+?)\/\/ CUSTOM_START/)
+            ?.pop() || "";
+        custom = custom.trim();
+        custom_end =
+          oldContent.match(/\/\/ CUSTOM_END([\s\S]+?)\/\/ CUSTOM_END/)?.pop() ||
+          "";
+        custom_end = custom_end.trim();
       }
-
-
     }
 
-    ListenerGenerator.getHookModels(this)
+    ListenerGenerator.getHookModels(this);
 
     await this.addFile(fileName)
       .destinationDir(ModelGenerator.directory)
@@ -87,7 +92,7 @@ export default class ModelGenerator extends BaseGenerator {
         imports: this.getImportsContent(),
         classname: this.getClassnameContent(),
         properties: this.getPropertiesContent(),
-        staticProperties: isProd() ? this.getProdStaticPropertiesContent() : '',
+        staticProperties: isProd() ? this.getProdStaticPropertiesContent() : "",
         columns: this.getColumnsContent(),
         computed: this.getComputedContent(),
         relations: await this.getRelationsContent(),
@@ -95,106 +100,130 @@ export default class ModelGenerator extends BaseGenerator {
         constructor: this.getConstructorContent(),
         custom,
         custom_end,
-      })
+      });
 
-    clearRequireCache()
+    clearRequireCache();
   }
 
   private getImportsContent(): string {
-    return isProd() ? this._getProdImportsContent() : this._getDevImportsContent()
+    return isProd()
+      ? this._getProdImportsContent()
+      : this._getDevImportsContent();
   }
   private _getProdImportsContent(): string {
     return `
 
 const Event =__importDefault(global[Symbol.for('ioc.use')]("Adonis/Core/Event"));
-${this.model.soft_deletes ? `
+${
+  this.model.soft_deletes
+    ? `
 const delete_1 = require("../../helpers/delete");
-` : ''}
 `
+    : ""
+}
+`;
   }
   private _getDevImportsContent(): string {
     return `import * as luxon from 'luxon'
 import * as Orm from '@ioc:Adonis/Lucid/Orm'
 import Event from '@ioc:Adonis/Core/Event'
 
-${this.model.soft_deletes ? `
+${
+  this.model.soft_deletes
+    ? `
 import {softDeleteQuery, softDelete} from "../../helpers/delete";
-` : ''}
 `
+    : ""
+}
+`;
   }
 
   private getClassnameContent(): string {
-    return `${this.model.name}`
+    return `${this.model.name}`;
   }
 
   private getPropertiesContent(): string {
-    return isProd() ?  this._getProdPropertiesContent() : this._getDevPropertiesContent()
+    return isProd()
+      ? this._getProdPropertiesContent()
+      : this._getDevPropertiesContent();
   }
 
   private _getProdPropertiesContent(): string {
+    const { settings = {} } = this.model;
 
-    const {settings = {}} = this.model
+    const { static_props = [] } = settings || {};
 
-    const {static_props = []} = (settings || {})
     return `
-  ${static_props.map(({
-   // @ts-ignore
-   prop_value,
-   // @ts-ignore
-   prop_name,})=>{
-        if(!prop_name || !prop_value){
-          return ''
+  ${static_props
+    .map(
+      ({
+        // @ts-ignore
+        prop_value,
+        // @ts-ignore
+        prop_name,
+      }) => {
+        if (!prop_name || !prop_value) {
+          return "";
         }
         return `
   static get ${prop_name}(){
     return \`${prop_value}\`
-  }`
+  }`;
       }
-    ).join('\n')}
+    )
+    .join("\n")}
 
-    `
+    `;
   }
 
   private _getDevPropertiesContent(): string {
-    const {settings = {}} = this.model
+    const { settings = {} } = this.model;
 
-    const {static_props = []} = settings
-
+    const { static_props = [] } = settings || {};
 
     return `
   public static table = '${this.table.name}'
-  ${static_props.map(({
-       // @ts-ignore
+  ${static_props
+    .map(
+      ({
+        // @ts-ignore
         prop_value,
-     // @ts-ignore
+        // @ts-ignore
         prop_name,
-    })=>{
-      if(!prop_name || !prop_value){
-          return ''
+      }) => {
+        if (!prop_name || !prop_value) {
+          return "";
         }
         return `
   static get ${prop_name}(){
     return \`${prop_value}\`
-  }`
+  }`;
       }
-    ).join('\n')}
+    )
+    .join("\n")}
 
-    `
+    `;
   }
 
   private getColumnsContent(): string {
-    return isProd() ? this._getProdColumnsContent() : this._getDevColumnsContent()
+    return isProd()
+      ? this._getProdColumnsContent()
+      : this._getDevColumnsContent();
   }
 
   private _getProdColumnsContent(): string {
-    let columns = this.columns.filter(column => column.type !== 'calculated')
+    let columns = this.columns.filter((column) => column.type !== "calculated");
     return `
 decorate([
   (0, Orm.column)({ isPrimary: true }),
   metadata("design:type", Number)
 ], ${this.model.name}.prototype, "id", void 0);
-${columns.map(column => column.altrp_model ? column.renderProdForModel() : '').join('')}
-${this.model.soft_deletes ? `
+${columns
+  .map((column) => (column.altrp_model ? column.renderProdForModel() : ""))
+  .join("")}
+${
+  this.model.soft_deletes
+    ? `
 decorate([
     (0, Orm.beforeFind)(),
     __metadata("design:type", Object)
@@ -207,54 +236,55 @@ decorate([
     (0, Orm.beforePaginate)(),
     __metadata("design:type", Object)
 ], ${this.model.name}, "softDeletesFetch", void 0);
-` : ''}
 `
+    : ""
+}
+`;
   }
 
   private _getDevColumnsContent(): string {
-    let columns = this.columns.filter(column => column.type !== 'calculated')
+    let columns = this.columns.filter((column) => column.type !== "calculated");
     return `
   @Orm.column({ isPrimary: true })
   public id: number
-${columns.map(column => column.renderForModel()).join('')}
-`
+${columns.map((column) => column.renderForModel()).join("")}
+`;
   }
 
   private async getMethodsContent(): Promise<string> {
+    const customizerQuery = Customizer.query();
 
-    const customizerQuery = Customizer.query()
+    customizerQuery.where("model_guid", this.model.guid);
+    customizerQuery.where("type", "method");
 
-    customizerQuery.where('model_guid', this.model.guid)
-    customizerQuery.where('type', 'method')
+    const methods = await customizerQuery;
 
-    const methods = await customizerQuery
+    let methodsContent = "";
 
-    let methodsContent = ''
+    for (const method of methods) {
+      try {
+        const startNode = method.getStartNode();
 
-    for(const method of methods){
-      try{
-        const startNode = method.getStartNode()
-
-        if(! startNode){
-          continue
+        if (!startNode) {
+          continue;
         }
-        let _static = startNode.isStaticMethod() ? ' static ' : ''
-        let _async = startNode.isAsyncMethod() ? ' async ' : ''
-        let params = startNode.getMethodParams()
+        let _static = startNode.isStaticMethod() ? " static " : "";
+        let _async = startNode.isAsyncMethod() ? " async " : "";
+        let params = startNode.getMethodParams();
         let methodContent = `
 /**
  * Automatically generated class method
  */
-${_static}${_async} ${method.name}(${params.join(', ')}){
+${_static}${_async} ${method.name}(${params.join(", ")}){
   ${startNode.getJSContent()}
           }
-`
-        methodsContent +=  methodContent
-      }catch (e) {
-        console.error('Error While Render Method-Customizer', e)
+`;
+        methodsContent += methodContent;
+      } catch (e) {
+        console.error("Error While Render Method-Customizer", e);
       }
     }
-    if(this.model.soft_deletes && ! isProd()){
+    if (this.model.soft_deletes && !isProd()) {
       return `
   @Orm.beforeFind()
   public static softDeletesFind = softDeleteQuery;
@@ -283,41 +313,44 @@ ${_static}${_async} ${method.name}(${params.join(', ')}){
       return false
     }
   }
-${methodsContent}`
+${methodsContent}`;
     }
-    return methodsContent
+    return methodsContent;
   }
 
   private getComputedContent(): string {
-    let columns = this.columns.filter(column => column.type === 'calculated')
+    let columns = this.columns.filter((column) => column.type === "calculated");
     return `
-${columns.map(column => column.renderForModel()).join('')}
-    `
+${columns.map((column) => column.renderForModel()).join("")}
+    `;
   }
 
   private async getRelationsContent(): Promise<string> {
-    let content = ``
-    for(const relation of this.altrp_relationships){
-      content += await relation.renderForModel()
+    let content = ``;
+    for (const relation of this.altrp_relationships) {
+      content += await relation.renderForModel();
     }
 
-    return content
+    return content;
   }
-
 
   private getProdStaticPropertiesContent() {
     return `
 ${this.model.name}.table = '${this.table.name}';
-${this.model.soft_deletes ? `
+${
+  this.model.soft_deletes
+    ? `
 ${this.model.name}.softDeletesFind = delete_1.softDeleteQuery;
 ${this.model.name}.softDeletesFetch = delete_1.softDeleteQuery;
-` : ''}
+`
+    : ""
+}
 `;
   }
 
   private getConstructorContent(): string {
-    if(this.model.soft_deletes){
-      return`
+    if (this.model.soft_deletes) {
+      return `
   constructor() {
     super(...arguments);
     this.delete = async () => {
@@ -334,8 +367,8 @@ ${this.model.name}.softDeletesFetch = delete_1.softDeleteQuery;
       }
     };
   }
-      `
+      `;
     }
-    return  ''
+    return "";
   }
 }

--- a/altrpnjs/app/altrp-templates/views/elements/widgets/cards.stub
+++ b/altrpnjs/app/altrp-templates/views/elements/widgets/cards.stub
@@ -1,1 +1,1 @@
-{{=<% %>=}}{{{<%={{ }}=%>renderCards(element{{id}}_settings, device, altrpContext){{=<% %>=}}}}}<%={{ }}=%>
+{{=<% %>=}}{{{<%={{ }}=%>renderCards(element{{id}}_settings, device, altrpContext, id){{=<% %>=}}}}}<%={{ }}=%>

--- a/altrpnjs/app/altrp-templates/views/elements/widgets/cards.stub
+++ b/altrpnjs/app/altrp-templates/views/elements/widgets/cards.stub
@@ -1,0 +1,1 @@
+{{=<% %>=}}{{{<%={{ }}=%>renderCards(element{{id}}_settings, device, altrpContext){{=<% %>=}}}}}<%={{ }}=%>

--- a/altrpnjs/helpers/const/DEFAULT_REACT_ELEMENTS.ts
+++ b/altrpnjs/helpers/const/DEFAULT_REACT_ELEMENTS.ts
@@ -28,7 +28,6 @@ const DEFAULT_REACT_ELEMENTS = [
   'input-gallery',
   'input-crop-image',
   'posts',
-  'cards',
   'breadcrumbs',
   'carousel',
   'map',

--- a/altrpnjs/helpers/const/DEFAULT_REACT_ELEMENTS.ts
+++ b/altrpnjs/helpers/const/DEFAULT_REACT_ELEMENTS.ts
@@ -28,6 +28,7 @@ const DEFAULT_REACT_ELEMENTS = [
   'input-gallery',
   'input-crop-image',
   'posts',
+  'cards',
   'breadcrumbs',
   'carousel',
   'map',

--- a/altrpnjs/helpers/widgets-renders/renderCards.ts
+++ b/altrpnjs/helpers/widgets-renders/renderCards.ts
@@ -1,0 +1,6 @@
+export default function renderCards(settings, device, context) {
+  // console.log("settings >>>>>>", settings);
+  // console.log("device >>>>>>", device);
+  // console.log("context >>>>>>", context);
+  return '<div class="altrp-cards">renderCards!!!!!!</div>';
+}

--- a/altrpnjs/helpers/widgets-renders/renderCards.ts
+++ b/altrpnjs/helpers/widgets-renders/renderCards.ts
@@ -1,16 +1,59 @@
 import Template from "App/Models/Template";
-import altrpRandomId from "../../helpers/altrpRandomId";
 
-export default async function renderCards(settings, device, context, id, { page, template: temp }) {
-  const {posts_per_page, posts_card_template} = settings;
-  const template = await Template.query().where('guid', posts_card_template).first();
-  const cardHtml = template ? (await template.getChildrenContent(device, id, {})) : '';
-  let cards = '';
+export default async function renderCards(
+  settings,
+  device,
+  context,
+  id,
+  { page, template: temp }
+) {
+  const {
+    posts_per_page,
+    posts_card_template,
+    posts_columns,
+    posts_rows_distance,
+    prev_text,
+    next_text,
+    posts_pagination_type,
+    hide_pre_page_button,
+    hide_next_page_button,
+  } = settings;
+  const template = await Template.query()
+    .where("guid", posts_card_template)
+    .first();
+  const cardHtml = template
+    ? await template.getChildrenContent(device, id, {})
+    : "";
+  const rowGap = `${posts_rows_distance.size}${posts_rows_distance.unit}`;
+
+  let cards = "";
   for (let i = 0; i < posts_per_page; i++) {
-    cards += `<div>${cardHtml.replace(/}}}/g, `${context}_${i}}}}`)}</div>`;
+    cards += `<div class="altrp-post">${cardHtml.replace(
+      /}}}/g,
+      `${context}_${i}}}}`
+    )}</div>`;
   }
 
-  return `<div class="altrp-cards">
-      ${cards}
-    </div>`;
+  const prevButton = `<button
+            class="altrp-pagination__previous state-disabled"
+            disabled
+          >
+            <span>${prev_text || ""}</span>
+          </button>`;
+
+  const nextButton = `<button
+            class="altrp-pagination__next"
+          >
+            <span>${next_text || ""}</span>
+          </button>`;
+
+  const pagination = `<div class="altrp-pagination-pages">
+          ${!hide_pre_page_button ? prevButton : ""}
+          ${!hide_next_page_button ? nextButton : ""}
+        </div>`;
+
+  return `<div class="altrp-cards" style="display: grid; grid-template-columns: repeat(${posts_columns}, 1fr); grid-row-gap: ${rowGap}">
+            ${cards}
+          </div>
+          ${pagination}`;
 }

--- a/altrpnjs/helpers/widgets-renders/renderCards.ts
+++ b/altrpnjs/helpers/widgets-renders/renderCards.ts
@@ -1,6 +1,16 @@
-export default function renderCards(settings, device, context) {
-  // console.log("settings >>>>>>", settings);
-  // console.log("device >>>>>>", device);
-  // console.log("context >>>>>>", context);
-  return '<div class="altrp-cards">renderCards!!!!!!</div>';
+import Template from "App/Models/Template";
+import altrpRandomId from "../../helpers/altrpRandomId";
+
+export default async function renderCards(settings, device, context, id, { page, template: temp }) {
+  const {posts_per_page, posts_card_template} = settings;
+  const template = await Template.query().where('guid', posts_card_template).first();
+  const cardHtml = template ? (await template.getChildrenContent(device, id, {})) : '';
+  let cards = '';
+  for (let i = 0; i < posts_per_page; i++) {
+    cards += `<div>${cardHtml.replace(/}}}/g, `${context}_${i}}}}`)}</div>`;
+  }
+
+  return `<div class="altrp-cards">
+      ${cards}
+    </div>`;
 }

--- a/altrpnjs/start/view.ts
+++ b/altrpnjs/start/view.ts
@@ -1,37 +1,38 @@
-import View from '@ioc:Adonis/Core/View'
+import View from "@ioc:Adonis/Core/View";
 
-import renderTabsSwitcher from '../helpers/widgets-renders/renderTabsSwitcher';
-import renderTabs from '../helpers/widgets-renders/renderTabs';
-import renderInputImageSelect from '../helpers/widgets-renders/renderInputImageSelect';
-import renderInputDate from '../helpers/widgets-renders/renderInputDate';
-import renderInputSelectTree from '../helpers/widgets-renders/renderInputSelectTree';
-import renderInputDateRange from '../helpers/widgets-renders/renderInputDateRange';
-import renderInputGallery from '../helpers/widgets-renders/renderInputGallery';
-import renderInputCropImage from '../helpers/widgets-renders/renderInputCropImage';
-import renderInputAccept from '../helpers/widgets-renders/renderInputAccept';
-import renderInputHidden from '../helpers/widgets-renders/renderInputHidden';
-import renderInputFile from '../helpers/widgets-renders/renderInputFile';
-import renderMap from '../helpers/widgets-renders/renderMap';
-import renderHeadingTypeAnimating from '../helpers/widgets-renders/renderHeadingTypeAnimating';
-import renderImageLightbox from '../helpers/widgets-renders/renderImageLightbox';
-import renderTree from '../helpers/widgets-renders/renderTree';
+import renderTabsSwitcher from "../helpers/widgets-renders/renderTabsSwitcher";
+import renderTabs from "../helpers/widgets-renders/renderTabs";
+import renderInputImageSelect from "../helpers/widgets-renders/renderInputImageSelect";
+import renderInputDate from "../helpers/widgets-renders/renderInputDate";
+import renderInputSelectTree from "../helpers/widgets-renders/renderInputSelectTree";
+import renderInputDateRange from "../helpers/widgets-renders/renderInputDateRange";
+import renderInputGallery from "../helpers/widgets-renders/renderInputGallery";
+import renderInputCropImage from "../helpers/widgets-renders/renderInputCropImage";
+import renderInputAccept from "../helpers/widgets-renders/renderInputAccept";
+import renderInputHidden from "../helpers/widgets-renders/renderInputHidden";
+import renderInputFile from "../helpers/widgets-renders/renderInputFile";
+import renderMap from "../helpers/widgets-renders/renderMap";
+import renderCards from "../helpers/widgets-renders/renderCards";
+import renderHeadingTypeAnimating from "../helpers/widgets-renders/renderHeadingTypeAnimating";
+import renderImageLightbox from "../helpers/widgets-renders/renderImageLightbox";
+import renderTree from "../helpers/widgets-renders/renderTree";
 
-import get_logo_url from '../helpers/get_logo_url'
-import getLocale from '../helpers/getLocale'
-import print_statics from '../helpers/print_statics'
-import config from '../helpers/config'
-import get_altrp_setting from '../helpers/get_altrp_setting'
-import getFavicons from '../helpers/getFavicons'
-import getResponsiveSetting from '../helpers/getResponsiveSetting'
-import * as _ from 'lodash'
-import getAddingClasses from '../helpers/getAddingClasses'
-import allowedForUser from '../helpers/allowedForUser'
-import getContent from '../helpers/getContent'
-import renderAsset from '../helpers/renderAsset'
-import renderButton from '../helpers/widgets-renders/renderButton'
-import renderImage from '../helpers/widgets-renders/renderImage'
-import renderHeading from '../helpers/widgets-renders/renderHeading'
-import renderIcon from '../helpers/widgets-renders/renderIcon'
+import get_logo_url from "../helpers/get_logo_url";
+import getLocale from "../helpers/getLocale";
+import print_statics from "../helpers/print_statics";
+import config from "../helpers/config";
+import get_altrp_setting from "../helpers/get_altrp_setting";
+import getFavicons from "../helpers/getFavicons";
+import getResponsiveSetting from "../helpers/getResponsiveSetting";
+import * as _ from "lodash";
+import getAddingClasses from "../helpers/getAddingClasses";
+import allowedForUser from "../helpers/allowedForUser";
+import getContent from "../helpers/getContent";
+import renderAsset from "../helpers/renderAsset";
+import renderButton from "../helpers/widgets-renders/renderButton";
+import renderImage from "../helpers/widgets-renders/renderImage";
+import renderHeading from "../helpers/widgets-renders/renderHeading";
+import renderIcon from "../helpers/widgets-renders/renderIcon";
 import renderHtml from "../helpers/widgets-renders/renderHtml";
 import renderDropbar from "../helpers/widgets-renders/renderDropbar";
 import renderVideo from "../helpers/widgets-renders/renderVideo";
@@ -52,7 +53,7 @@ import renderCarousel from "../helpers/widgets-renders/renderCarousel";
 import renderProgressBar from "../helpers/widgets-renders/renderProgressBar";
 import renderInputWysiwyg from "../helpers/widgets-renders/renderInputWysiwyg";
 import renderScheduler from "../helpers/widgets-renders/renderScheduler";
-import renderTournament from '../helpers/widgets-renders/renderTournament';
+import renderTournament from "../helpers/widgets-renders/renderTournament";
 import renderDivider from "../helpers/widgets-renders/renderDivider";
 import renderSectionBG from "../helpers/renderSectionBG";
 import getColumnClasses from "../helpers/getColumnClasses";
@@ -63,70 +64,71 @@ import renderText from "../helpers/widgets-renders/renderText";
 import data_get from "../helpers/data_get";
 import getSectionWidthClass from "../helpers/widgets-renders/getSectionWidthClass";
 
-View.global('get_logo_url', get_logo_url)
-View.global('getLocale', getLocale)
-View.global('config', config)
-View.global('print_statics', print_statics)
-View.global('get_altrp_setting', get_altrp_setting)
-View.global('getFavicons', getFavicons)
-View.global('getResponsiveSetting', getResponsiveSetting)
-View.global('getAddingClasses', getAddingClasses)
-View.global('allowedForUser', allowedForUser)
-View.global('getContent', getContent)
-View.global('renderAsset', renderAsset)
-View.global('renderSectionBG', renderSectionBG)
-View.global('getColumnClasses', getColumnClasses)
-View.global('getLatestVersion', getLatestVersion)
-View.global('data_get', data_get)
-View.global('getSectionWidthClass', getSectionWidthClass)
+View.global("get_logo_url", get_logo_url);
+View.global("getLocale", getLocale);
+View.global("config", config);
+View.global("print_statics", print_statics);
+View.global("get_altrp_setting", get_altrp_setting);
+View.global("getFavicons", getFavicons);
+View.global("getResponsiveSetting", getResponsiveSetting);
+View.global("getAddingClasses", getAddingClasses);
+View.global("allowedForUser", allowedForUser);
+View.global("getContent", getContent);
+View.global("renderAsset", renderAsset);
+View.global("renderSectionBG", renderSectionBG);
+View.global("getColumnClasses", getColumnClasses);
+View.global("getLatestVersion", getLatestVersion);
+View.global("data_get", data_get);
+View.global("getSectionWidthClass", getSectionWidthClass);
 /**
  * RENDERS START
  */
-View.global('renderButton', renderButton)
-View.global('renderImage', renderImage)
-View.global('renderHeading', renderHeading)
-View.global('renderTabsSwitcher', renderTabsSwitcher)
-View.global('renderTournament', renderTournament)
-View.global('renderTabs', renderTabs)
-View.global('renderIcon', renderIcon)
-View.global('renderHtml', renderHtml)
-View.global('renderDropbar', renderDropbar)
-View.global('renderVideo', renderVideo)
-View.global('renderInputTextAutocomplete', renderInputTextAutocomplete)
-View.global('renderInputTextCommon', renderInputTextCommon)
-View.global('renderInputTextarea', renderInputTextarea)
-View.global('renderInputCheckbox', renderInputCheckbox)
-View.global('renderInputRadio', renderInputRadio)
-View.global('renderInputSelect', renderInputSelect)
-View.global('renderInputSelect2', renderInputSelect2)
-View.global('renderInputMultiSelect', renderInputMultiSelect)
-View.global('renderInputSlider', renderInputSlider)
-View.global('renderInputRangeSlider', renderInputRangeSlider)
-View.global('renderInputWysiwyg', renderInputWysiwyg)
-View.global('renderGallery', renderGallery)
-View.global('renderCarousel', renderCarousel)
-View.global('renderProgressBar', renderProgressBar)
-View.global('renderScheduler', renderScheduler)
-View.global('renderAccordion', renderAccordion)
-View.global('renderStars', renderStars)
-View.global('renderInputSelectTree', renderInputSelectTree)
-View.global('renderInputImageSelect', renderInputImageSelect)
-View.global('renderInputDate', renderInputDate)
-View.global('renderInputDateRange', renderInputDateRange)
-View.global('renderInputGallery', renderInputGallery)
-View.global('renderInputCropImage', renderInputCropImage)
-View.global('renderInputAccept', renderInputAccept)
-View.global('renderInputHidden', renderInputHidden)
-View.global('renderInputFile', renderInputFile)
-View.global('renderInputPagination', renderInputPagination)
-View.global('renderMap', renderMap)
-View.global('renderHeadingTypeAnimating', renderHeadingTypeAnimating)
-View.global('renderImageLightbox', renderImageLightbox)
-View.global('renderTree', renderTree)
-View.global('renderDivider', renderDivider)
-View.global('renderFeedback', renderFeedback)
-View.global('renderText', renderText)
+View.global("renderButton", renderButton);
+View.global("renderImage", renderImage);
+View.global("renderHeading", renderHeading);
+View.global("renderTabsSwitcher", renderTabsSwitcher);
+View.global("renderTournament", renderTournament);
+View.global("renderTabs", renderTabs);
+View.global("renderIcon", renderIcon);
+View.global("renderHtml", renderHtml);
+View.global("renderDropbar", renderDropbar);
+View.global("renderVideo", renderVideo);
+View.global("renderInputTextAutocomplete", renderInputTextAutocomplete);
+View.global("renderInputTextCommon", renderInputTextCommon);
+View.global("renderInputTextarea", renderInputTextarea);
+View.global("renderInputCheckbox", renderInputCheckbox);
+View.global("renderInputRadio", renderInputRadio);
+View.global("renderInputSelect", renderInputSelect);
+View.global("renderInputSelect2", renderInputSelect2);
+View.global("renderInputMultiSelect", renderInputMultiSelect);
+View.global("renderInputSlider", renderInputSlider);
+View.global("renderInputRangeSlider", renderInputRangeSlider);
+View.global("renderInputWysiwyg", renderInputWysiwyg);
+View.global("renderGallery", renderGallery);
+View.global("renderCarousel", renderCarousel);
+View.global("renderProgressBar", renderProgressBar);
+View.global("renderScheduler", renderScheduler);
+View.global("renderAccordion", renderAccordion);
+View.global("renderStars", renderStars);
+View.global("renderInputSelectTree", renderInputSelectTree);
+View.global("renderInputImageSelect", renderInputImageSelect);
+View.global("renderInputDate", renderInputDate);
+View.global("renderInputDateRange", renderInputDateRange);
+View.global("renderInputGallery", renderInputGallery);
+View.global("renderInputCropImage", renderInputCropImage);
+View.global("renderInputAccept", renderInputAccept);
+View.global("renderInputHidden", renderInputHidden);
+View.global("renderInputFile", renderInputFile);
+View.global("renderInputPagination", renderInputPagination);
+View.global("renderMap", renderMap);
+View.global("renderCards", renderCards);
+View.global("renderHeadingTypeAnimating", renderHeadingTypeAnimating);
+View.global("renderImageLightbox", renderImageLightbox);
+View.global("renderTree", renderTree);
+View.global("renderDivider", renderDivider);
+View.global("renderFeedback", renderFeedback);
+View.global("renderText", renderText);
 /**
  * RENDERS END
  */
-View.global('isEmpty', _.isEmpty)
+View.global("isEmpty", _.isEmpty);

--- a/resources/modules/editor/src/js/classes/elements/Cards.js
+++ b/resources/modules/editor/src/js/classes/elements/Cards.js
@@ -1,0 +1,1376 @@
+import BaseElement from "./BaseElement";
+import TableIcon from "../../../svgs/post-list.svg";
+import {
+  CONTROLLER_TEXTAREA,
+  CONTROLLER_SWITCHER,
+  CONTROLLER_COLOR,
+  CONTROLLER_DIMENSIONS,
+  CONTROLLER_SELECT,
+  CONTROLLER_SLIDER,
+  TAB_CONTENT,
+  CONTROLLER_TYPOGRAPHIC,
+  TAB_STYLE,
+  CONTROLLER_NUMBER,
+  CONTROLLER_SHADOW,
+  CONTROLLER_GRADIENT,
+  CONTROLLER_MEDIA,
+  CONTROLLER_HEADING,
+  CONTROLLER_SELECT2,
+} from "../modules/ControllersManager";
+import { advancedTabControllers } from "../../decorators/register-controllers";
+
+class Cards extends BaseElement {
+  static getName() {
+    return "cards";
+  }
+  static getTitle() {
+    return "new Cards";
+  }
+  static getIconComponent() {
+    return TableIcon;
+  }
+  static getType() {
+    return "widget";
+  }
+  static getGroup() {
+    return "Advanced";
+  }
+  _registerControls() {
+    if (this.controllersRegistered) {
+      return;
+    }
+
+    this.startControlSection("posts_content_datasource", {
+      tab: TAB_CONTENT,
+      label: "Data Source",
+    });
+
+    this.addControl("choose_datasource", {
+      type: CONTROLLER_SELECT,
+      label: "Choose Data Source",
+      options: [
+        {
+          label: "From Page Data Source",
+          value: "datasource",
+        },
+      ],
+      default: "datasource",
+      locked: true,
+    });
+
+    this.addControl("posts_datasource", {
+      label: "Path",
+      type: CONTROLLER_TEXTAREA,
+      conditions: {
+        choose_datasource: "datasource",
+      },
+      locked: true,
+    });
+
+    this.addControl("posts_query_heading", {
+      type: CONTROLLER_HEADING,
+      label: "Query",
+      conditions: {
+        choose_datasource: "query",
+      },
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("posts_layout", {
+      tab: TAB_CONTENT,
+      label: "Layout",
+    });
+
+    this.addControl("posts_columns", {
+      type: CONTROLLER_SELECT,
+      label: "Columns",
+      options: [
+        {
+          label: "1",
+          value: 1,
+        },
+        {
+          label: "2",
+          value: 2,
+        },
+        {
+          label: "3",
+          value: 3,
+        },
+        {
+          label: "4",
+          value: 4,
+        },
+        {
+          label: "5",
+          value: 5,
+        },
+        {
+          label: "6",
+          value: 6,
+        },
+      ],
+      default: 3,
+      locked: true,
+    });
+
+    this.addControl("switch_overflow_hidden_template", {
+      type: CONTROLLER_SWITCHER,
+      locked: true,
+      label: "Delete Overflow Hidden",
+    });
+
+    this.addControl("posts_card_template", {
+      type: CONTROLLER_SELECT2,
+      prefetch_options: true,
+      label: "Template",
+      isClearable: true,
+      options_resource:
+        "/admin/ajax/templates/options?template_type=card&value=guid",
+      gotoLink: {
+        linkTemplate: "/admin/editor?template_id={id}",
+        textTemplate: "Go to Template",
+      },
+      nullable: true,
+      locked: true,
+    });
+
+    this.addControl("posts_card_hover_template", {
+      type: CONTROLLER_SELECT2,
+      prefetch_options: true,
+      label: "Hover Template",
+      isClearable: true,
+      options_resource:
+        "/admin/ajax/templates/options?template_type=card&value=guid",
+      gotoLink: {
+        linkTemplate: "/admin/editor?template_id={id}",
+        textTemplate: "Go to Template",
+      },
+      nullable: true,
+      locked: true,
+    });
+    this.addControl("load-html-cards", {
+      label: "Loading Raw Html for Cards",
+      type: CONTROLLER_SWITCHER,
+      responsive: false,
+      locked: true,
+    });
+    this.addControl("posts_transition_type", {
+      type: CONTROLLER_SELECT,
+      label: "Select Transition Type",
+      options: [
+        {
+          label: "Left to Right",
+          value: "left",
+        },
+        {
+          label: "Right to Left",
+          value: "right",
+        },
+        {
+          label: "Top to Bottom",
+          value: "top",
+        },
+        {
+          label: "Bottom to Top",
+          value: "bottom",
+        },
+        {
+          label: "Fade In",
+          value: "fade",
+        },
+        {
+          label: "Zoom",
+          value: "zoom",
+        },
+      ],
+      default: "left",
+      locked: true,
+    });
+
+    this.addControl("posts_per_page", {
+      type: CONTROLLER_NUMBER,
+      label: "Posts per Page",
+      //locked: true,
+      default: 3,
+    });
+
+    this.addControl("posts_rows_distance", {
+      type: CONTROLLER_SLIDER,
+      label: "Rows Distance",
+      default: {
+        size: 20,
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+      max: 120,
+      min: 0,
+      locked: true,
+    });
+
+    this.addControl("posts_pagination_type", {
+      type: CONTROLLER_SELECT,
+      label: "Pagination Type",
+      options: [
+        {
+          value: "",
+          label: "None",
+        },
+        {
+          value: "prev_next",
+          label: "Prev/Next",
+        },
+        {
+          value: "lazy_load",
+          label: "Lazy Loading",
+        },
+        {
+          value: "pages",
+          label: "Pages",
+        },
+      ],
+      default: "prev_next",
+      locked: true,
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("posts_page_settings", {
+      label: "Pages",
+      conditions: {
+        posts_pagination_type: "pages",
+      },
+    });
+
+    this.addControl("first_last_buttons_count", {
+      type: CONTROLLER_NUMBER,
+      label: "First-Last Buttons Count",
+    });
+
+    this.addControl("middle_buttons_count", {
+      type: CONTROLLER_NUMBER,
+      label: "Middle Buttons Count",
+    });
+
+    this.addControl("is_with_ellipsis", {
+      type: CONTROLLER_SWITCHER,
+      label: "Show Ellipsis",
+      default: true,
+    });
+
+    this.addControl("hide_pre_page_button", {
+      type: CONTROLLER_SWITCHER,
+      label: "Hide Prev Page Button",
+      default: false,
+    });
+
+    this.addControl("hide_next_page_button", {
+      type: CONTROLLER_SWITCHER,
+      label: "Hide Next Page Button",
+      default: false,
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("posts_pagination_section", {
+      label: "Pagination",
+      conditions: {
+        "posts_pagination_type!": "",
+      },
+    });
+
+    this.addControl("query_sync", {
+      label: "Sync With Query String",
+      type: CONTROLLER_SWITCHER,
+      responsive: false,
+      locked: true,
+    });
+
+    this.addControl("query_update", {
+      label: "Reset `page` and `pageSize` Params on Query String Updates",
+      type: CONTROLLER_SWITCHER,
+      responsive: false,
+      conditions: {
+        query_sync: true,
+      },
+      locked: true,
+    });
+
+    this.addControl("query_max_page", {
+      label: "Path to Page Count",
+      responsive: false,
+      conditions: {
+        query_sync: true,
+      },
+      locked: true,
+    });
+
+    this.addControl("prev_text", {
+      label: "Prev Text",
+      default: "Prev Page",
+      locked: true,
+    });
+
+    this.addControl("prev_icon", {
+      type: CONTROLLER_MEDIA,
+      locked: true,
+      label: "Prev Page Icon",
+    });
+
+    this.addControl("prev_icon_position", {
+      type: CONTROLLER_SELECT,
+      label: "Prev Icon Position",
+      default: "default",
+      options: [
+        {
+          value: "row",
+          label: "Right",
+        },
+        {
+          value: "row-reverse",
+          label: "Left",
+        },
+        {
+          value: "column",
+          label: "Bottom",
+        },
+        {
+          value: "column-reverse",
+          label: "Top",
+        },
+      ],
+    });
+
+    this.addControl("next_text", {
+      label: "Next Text",
+      default: "Next Page",
+      locked: true,
+    });
+
+    this.addControl("next_icon", {
+      type: CONTROLLER_MEDIA,
+      locked: true,
+      label: "Next Page Icon",
+    });
+
+    this.addControl("next_icon_position", {
+      type: CONTROLLER_SELECT,
+      label: "Next Icon Position",
+      default: "default",
+      options: [
+        {
+          value: "row",
+          label: "Right",
+        },
+        {
+          value: "row-reverse",
+          label: "Left",
+        },
+        {
+          value: "column",
+          label: "Bottom",
+        },
+        {
+          value: "column-reverse",
+          label: "Top",
+        },
+      ],
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("posts_layout_styles", {
+      tab: TAB_STYLE,
+      label: "Layout",
+    });
+
+    this.addControl("posts_alignment", {
+      type: CONTROLLER_SELECT,
+      label: "Content Alignment",
+      default: "top",
+      options: [
+        {
+          label: "top",
+          value: "flex-start",
+        },
+        {
+          label: "bottom",
+          value: "flex-end",
+        },
+      ],
+    });
+
+    this.addControl("position_padding", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Padding",
+      default: {
+        unit: "px",
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("posts_bottom_space", {
+      type: CONTROLLER_SLIDER,
+      label: "Bottom Space",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+      max: 50,
+      min: 0,
+    });
+
+    this.addControl("posts_columns_gap", {
+      label: "Columns Gap",
+      locked: true,
+    });
+
+    this.addControl("posts_rows_gap", {
+      label: "Rows Gap",
+      max: 100,
+      locked: true,
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("posts_border_section", {
+      tab: TAB_STYLE,
+      label: "Border",
+    });
+
+    this.addControl("posts_border_type", {
+      type: CONTROLLER_SELECT,
+      label: "Border Type",
+      options: [
+        {
+          value: "none",
+          label: "None",
+        },
+        {
+          value: "solid",
+          label: "Solid",
+        },
+        {
+          value: "double",
+          label: "Double",
+        },
+        {
+          value: "dotted",
+          label: "Dotted",
+        },
+        {
+          value: "dashed",
+          label: "Dashed",
+        },
+        {
+          value: "groove",
+          label: "Groove",
+        },
+      ],
+    });
+
+    this.addControl("posts_border_width", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Border Width",
+      default: {
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("posts_border_color", {
+      type: CONTROLLER_COLOR,
+      label: "Border Color",
+    });
+
+    this.addControl("border_radius", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Border Radius",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("style_background_shadow", {
+      type: CONTROLLER_SHADOW,
+      label: "Shadow",
+      default: {
+        // blur: 0,
+        // horizontal: 0,
+        // vertical: 0,
+        // opacity: 1,
+        // spread: 0,
+        // colorRGB: 'rgb(0, 0, 0)',
+        // color: 'rgb(0, 0, 0)',
+        // colorPickedHex: '#000000',
+        // type: ""
+      },
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("posts_background_section", {
+      tab: TAB_STYLE,
+      label: "Background",
+    });
+
+    this.addControl("posts_background_color", {
+      type: CONTROLLER_COLOR,
+      label: "Background color",
+    });
+
+    this.addControl("gradient", {
+      type: CONTROLLER_GRADIENT,
+      label: "Gradient",
+      default: {
+        isWithGradient: false,
+        firstColor: "rgba(97,206,112,1)",
+        firstPoint: "100",
+        secondColor: "rgba(242,41,91,1)",
+        secondPoint: "0",
+        angle: "0",
+        value: "",
+      },
+    });
+
+    this.addControl("posts_background_image", {
+      type: CONTROLLER_MEDIA,
+      label: "Background Image",
+      default: { url: "" },
+    });
+
+    this.addControl("background_position", {
+      type: CONTROLLER_SELECT,
+      options: [
+        {
+          value: "top left",
+          label: "top left",
+        },
+        {
+          value: "top",
+          label: "top",
+        },
+        {
+          value: "top right",
+          label: "top right",
+        },
+        {
+          value: "right",
+          label: "right",
+        },
+        {
+          value: "bottom right",
+          label: "bottom right",
+        },
+        {
+          value: "bottom",
+          label: "bottom",
+        },
+        {
+          value: "bottom left",
+          label: "bottom left",
+        },
+        {
+          value: "left",
+          label: "left",
+        },
+        {
+          value: "center",
+          label: "center",
+        },
+      ],
+      label: "Background Position",
+      default: "top left",
+    });
+
+    this.addControl("background_attachment", {
+      type: CONTROLLER_SELECT,
+      options: [
+        {
+          value: "scroll",
+          label: "scroll",
+        },
+        {
+          value: "fixed",
+          label: "fixed",
+        },
+        {
+          value: "local",
+          label: "local",
+        },
+      ],
+      label: "Background Attachment",
+      default: "scroll",
+    });
+
+    this.addControl("background_repeat", {
+      type: CONTROLLER_SELECT,
+      options: [
+        {
+          value: "repeat",
+          label: "repeat",
+        },
+        {
+          value: "repeat-x",
+          label: "repeat-x",
+        },
+        {
+          value: "repeat-y",
+          label: "repeat-y",
+        },
+        {
+          value: "space",
+          label: "space",
+        },
+        {
+          value: "round",
+          label: "round",
+        },
+        {
+          value: "no-repeat",
+          label: "no-repeat",
+        },
+      ],
+      label: "Background Repeat",
+      default: "repeat",
+    });
+
+    this.addControl("background_image_width", {
+      type: CONTROLLER_SLIDER,
+      label: "Width",
+      default: {
+        size: 100,
+        unit: "px",
+      },
+      conditions: {
+        background_size: [""],
+      },
+      units: ["px", "%", "vh", "vw"],
+      max: 1000,
+      min: 0,
+    });
+
+    this.addControl("background_size", {
+      type: CONTROLLER_SELECT,
+      options: [
+        {
+          value: "unset",
+          label: "unset",
+        },
+        {
+          value: "cover",
+          label: "cover",
+        },
+        {
+          value: "contain",
+          label: "contain",
+        },
+        {
+          value: "",
+          label: "set width",
+        },
+      ],
+      label: "Background Size",
+      default: "unset",
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("posts_pagination_style_section", {
+      label: "Pagination",
+      tab: TAB_STYLE,
+      conditions: {
+        "posts_pagination_type!": "",
+      },
+    });
+
+    this.addControl("hide_page_input", {
+      type: CONTROLLER_SWITCHER,
+      label: "Hide Page Input",
+      default: false,
+      conditions: { posts_pagination_type: "pages" },
+    });
+
+    this.addControl("hide_pagination_select", {
+      type: CONTROLLER_SWITCHER,
+      label: "Hide Pagination Select",
+      default: false,
+      conditions: { posts_pagination_type: "pages" },
+    });
+
+    this.addControl("posts_pagination_padding", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Wrapper Padding",
+      default: {
+        unit: "px",
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("table_style_pagination_typographic", {
+      type: CONTROLLER_TYPOGRAPHIC,
+      label: "Typographic",
+      conditions: { posts_pagination_type: "pages" },
+    });
+
+    this.endControlSection();
+    //<editor-fold desc="posts_prev_style_section">
+
+    this.startControlSection("posts_prev_style_section", {
+      label: "Prev Button",
+      tab: TAB_STYLE,
+      conditions: {
+        "posts_pagination_type!": "",
+      },
+    });
+
+    this.addControl("posts_prev_margin", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Margin",
+      default: {
+        unit: "px",
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("posts_prev_padding", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Padding",
+      default: {
+        unit: "px",
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("posts_prev_color", {
+      type: CONTROLLER_COLOR,
+      label: "Color",
+      default: {
+        color: "",
+        colorPickedHex: "#000",
+      },
+    });
+
+    this.addControl("posts_prev_typographic", {
+      type: CONTROLLER_TYPOGRAPHIC,
+      label: "Typographic",
+    });
+
+    this.addControl("posts_prev_border_type", {
+      type: CONTROLLER_SELECT,
+      label: "Border Type",
+      options: [
+        {
+          value: "none",
+          label: "None",
+        },
+        {
+          value: "solid",
+          label: "Solid",
+        },
+        {
+          value: "double",
+          label: "Double",
+        },
+        {
+          value: "dotted",
+          label: "Dotted",
+        },
+        {
+          value: "dashed",
+          label: "Dashed",
+        },
+        {
+          value: "groove",
+          label: "Groove",
+        },
+      ],
+    });
+
+    this.addControl("posts_prev_border_width", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Border Width",
+      default: {
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("posts_prev_border_color", {
+      type: CONTROLLER_COLOR,
+      label: "Border Color",
+    });
+
+    this.addControl("border_prev_radius", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Border Radius",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("style_prev_background_shadow", {
+      type: CONTROLLER_SHADOW,
+      label: "Shadow",
+      default: {},
+    });
+
+    this.addControl("prev_icon_padding", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Prev Icon Margin",
+      default: {
+        unit: "px",
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("prev_icon_size", {
+      type: CONTROLLER_SLIDER,
+      label: "Prev Icon Size",
+      units: ["px", "%", "vh", "vw"],
+      max: 100,
+      min: 0,
+    });
+
+    this.addControl("prev_icon_color", {
+      type: CONTROLLER_COLOR,
+      label: "Prev Icon Color",
+    });
+
+    this.endControlSection();
+    //</editor-fold>
+
+    //<editor-fold desc="posts_next_style_section">
+
+    this.startControlSection("posts_next_style_section", {
+      label: "Next Button",
+      tab: TAB_STYLE,
+      conditions: {
+        "posts_pagination_type!": "",
+      },
+    });
+
+    this.addControl("posts_next_margin", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Margin",
+      default: {
+        unit: "px",
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("posts_next_padding", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Padding",
+      default: {
+        unit: "px",
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("posts_next_color", {
+      type: CONTROLLER_COLOR,
+      label: "Color",
+      default: {
+        color: "",
+        colorPickedHex: "#000",
+      },
+    });
+
+    this.addControl("posts_next_typographic", {
+      type: CONTROLLER_TYPOGRAPHIC,
+      label: "Typographic",
+    });
+
+    this.addControl("posts_next_border_type", {
+      type: CONTROLLER_SELECT,
+      label: "Border Type",
+      options: [
+        {
+          value: "none",
+          label: "None",
+        },
+        {
+          value: "solid",
+          label: "Solid",
+        },
+        {
+          value: "double",
+          label: "Double",
+        },
+        {
+          value: "dotted",
+          label: "Dotted",
+        },
+        {
+          value: "dashed",
+          label: "Dashed",
+        },
+        {
+          value: "groove",
+          label: "Groove",
+        },
+      ],
+    });
+
+    this.addControl("posts_next_border_width", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Border Width",
+      default: {
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("posts_next_border_color", {
+      type: CONTROLLER_COLOR,
+      label: "Border Color",
+    });
+
+    this.addControl("border_next_radius", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Border Radius",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("style_next_background_shadow", {
+      type: CONTROLLER_SHADOW,
+      label: "Shadow",
+      default: {},
+    });
+
+    this.addControl("next_icon_margin", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Next Icon Margin",
+      default: {
+        unit: "px",
+        bind: true,
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("next_icon_size", {
+      type: CONTROLLER_SLIDER,
+      label: "Next Icon Size",
+      units: ["px", "%", "vh", "vw"],
+      max: 100,
+      min: 0,
+    });
+
+    this.addControl("next_icon_color", {
+      type: CONTROLLER_COLOR,
+      label: "Next Icon Color",
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("table_style_page_buttons", {
+      tab: TAB_STYLE,
+      label: "Page Count Buttons",
+      conditions: {
+        "hide_pages_buttons_button!": true,
+        posts_pagination_type: "pages",
+      },
+    });
+
+    this.addControl("count_buttons_margin", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Page Count Buttons Margin",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("count_button_item_margin", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Page Count Item Margin",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("table_style_pagination_count_text_color", {
+      type: CONTROLLER_COLOR,
+      label: "Count Text Color",
+    });
+
+    this.addControl("table_style_pagination_count_background_color", {
+      type: CONTROLLER_COLOR,
+      label: "Count Background Color",
+    });
+
+    this.addControl("table_style_pagination_count_item_background_color", {
+      type: CONTROLLER_COLOR,
+      label: "Count Item background color",
+    });
+
+    this.addControl("table_style_pagination_active_count_text_color", {
+      type: CONTROLLER_COLOR,
+      label: "Active Count text color",
+    });
+
+    this.addControl(
+      "table_style_pagination_active_count_item_background_color",
+      {
+        type: CONTROLLER_COLOR,
+        label: "Active Count Item background color",
+      }
+    );
+
+    this.addControl("table_style_pagination_padding_count", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Count Padding",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("width_count_item", {
+      type: CONTROLLER_SLIDER,
+      label: "Item Width",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("height_count_item", {
+      type: CONTROLLER_SLIDER,
+      label: "Item Height",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("table_style_item_count_pagination_typographic", {
+      type: CONTROLLER_TYPOGRAPHIC,
+      label: "Item Count Typographic",
+    });
+
+    this.addControl("table_style_pagination_count_item_border_type", {
+      type: CONTROLLER_SELECT,
+      label: "Item Count Border type",
+      options: [
+        {
+          value: "none",
+          label: "None",
+        },
+        {
+          value: "solid",
+          label: "Solid",
+        },
+        {
+          value: "double",
+          label: "Double",
+        },
+        {
+          value: "dotted",
+          label: "Dotted",
+        },
+        {
+          value: "dashed",
+          label: "Dashed",
+        },
+        {
+          value: "groove",
+          label: "Groove",
+        },
+      ],
+    });
+
+    this.addControl("table_style_pagination_count_item_border_width", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Item Count Border Width",
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("table_style_count_item_border_radius", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Item Count Border Radius",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("table_style_pagination_count_item_border_color", {
+      type: CONTROLLER_COLOR,
+      label: "Item Count Border color",
+    });
+
+    this.addControl("table_style_pagination_active_count_item_border_color", {
+      type: CONTROLLER_COLOR,
+      label: "Active Item Count Border color",
+    });
+
+    this.addControl("pagination_count_item_shadow", {
+      type: CONTROLLER_SHADOW,
+      label: "Item Count Shadow",
+    });
+
+    this.addControl("ellipsis_heading", {
+      type: CONTROLLER_HEADING,
+      label: "Ellipsis",
+      conditions: {
+        is_with_ellipsis: true,
+      },
+    });
+
+    this.addControl("ellipsis_margin", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Ellipsis Margin",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+      conditions: {
+        is_with_ellipsis: true,
+      },
+    });
+
+    this.addControl("ellipsis_color", {
+      type: CONTROLLER_COLOR,
+      label: "Ellipsis Color",
+      conditions: {
+        is_with_ellipsis: true,
+      },
+    });
+
+    this.addControl("ellipsis_typographic", {
+      type: CONTROLLER_TYPOGRAPHIC,
+      label: "Ellipsis Typographic",
+      conditions: {
+        is_with_ellipsis: true,
+      },
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("table_style_page_input", {
+      tab: TAB_STYLE,
+      label: "Page Input",
+      conditions: {
+        "hide_page_input!": true,
+        posts_pagination_type: "pages",
+      },
+    });
+
+    this.addControl("goto-page_margin", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Page Input Margin",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("page_input_padding", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Page Input Padding",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("page_input_text_color", {
+      type: CONTROLLER_COLOR,
+      label: "Page Input text color",
+      default: {
+        color: "",
+        colorPickedHex: "",
+      },
+    });
+
+    this.addControl("page_input_background_color", {
+      type: CONTROLLER_COLOR,
+      label: "Page Input background color",
+    });
+
+    this.addControl("table_style_page_input_pagination_typographic", {
+      type: CONTROLLER_TYPOGRAPHIC,
+      label: "Page Input Typographic",
+    });
+
+    this.addControl("page_input_border_type", {
+      type: CONTROLLER_SELECT,
+      label: "Page Input Border type",
+      options: [
+        {
+          value: "none",
+          label: "None",
+        },
+        {
+          value: "solid",
+          label: "Solid",
+        },
+        {
+          value: "double",
+          label: "Double",
+        },
+        {
+          value: "dotted",
+          label: "Dotted",
+        },
+        {
+          value: "dashed",
+          label: "Dashed",
+        },
+        {
+          value: "groove",
+          label: "Groove",
+        },
+      ],
+    });
+
+    this.addControl("page_input_border_width", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Page Input Border width",
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("page_input_border_radius", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Page Input Border Radius",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("page_input_border_color", {
+      type: CONTROLLER_COLOR,
+      label: "Page Input Border Color",
+    });
+
+    this.addControl("page_input_shadow", {
+      type: CONTROLLER_SHADOW,
+      label: "Item Count Shadow",
+    });
+
+    this.endControlSection();
+
+    this.startControlSection("table_style_pagination_select", {
+      tab: TAB_STYLE,
+      label: "Pagination Select",
+      conditions: {
+        "hide_pagination_select!": true,
+        "inner_page_count_options!": "",
+        posts_pagination_type: "pages",
+      },
+    });
+
+    this.addControl("pagination_select_margin", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Pagination Select Margin",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("pagination_select_padding", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Pagination Select Padding",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("table_style_pagination_select__pagination_typographic", {
+      type: CONTROLLER_TYPOGRAPHIC,
+      label: "Pagination Select Typographic",
+    });
+
+    this.addControl("pagination_select_border_type", {
+      type: CONTROLLER_SELECT,
+      label: "Pagination Select Border type",
+      options: [
+        {
+          value: "none",
+          label: "None",
+        },
+        {
+          value: "solid",
+          label: "Solid",
+        },
+        {
+          value: "double",
+          label: "Double",
+        },
+        {
+          value: "dotted",
+          label: "Dotted",
+        },
+        {
+          value: "dashed",
+          label: "Dashed",
+        },
+        {
+          value: "groove",
+          label: "Groove",
+        },
+      ],
+    });
+
+    this.addControl("pagination_select_border_width", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Pagination Select Border width",
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("pagination_select_border_radius", {
+      type: CONTROLLER_DIMENSIONS,
+      label: "Pagination Select Border Radius",
+      default: {
+        unit: "px",
+      },
+      units: ["px", "%", "vh", "vw"],
+    });
+
+    this.addControl("pagination_select_border_color", {
+      type: CONTROLLER_COLOR,
+      label: "Pagination Select Border Color",
+    });
+
+    this.addControl("pagination_select_shadow", {
+      type: CONTROLLER_SHADOW,
+      label: "Pagination Select Shadow",
+    });
+
+    this.addControl("pagination_select_text_color", {
+      type: CONTROLLER_COLOR,
+      label: "Pagination Select text color",
+    });
+
+    this.addControl("pagination_select_background_color", {
+      type: CONTROLLER_COLOR,
+      label: "Pagination Select background color",
+    });
+
+    this.endControlSection();
+    //</editor-fold>
+
+    advancedTabControllers(this);
+  }
+}
+
+export default Cards;

--- a/resources/modules/editor/src/js/components/altrp-posts/altrp-posts.scss
+++ b/resources/modules/editor/src/js/components/altrp-posts/altrp-posts.scss
@@ -50,7 +50,8 @@
   opacity: 1;
 
 }
-.altrp-widget_posts{
+.altrp-widget_posts,
+.altrp-widget_cards {
   & > div > .altrp-pagination-pages,
   & > .altrp-pagination-pages{
     justify-content: center;

--- a/resources/modules/editor/src/js/components/widgets/CardsWidget.js
+++ b/resources/modules/editor/src/js/components/widgets/CardsWidget.js
@@ -1,0 +1,106 @@
+import Query from "../../classes/Query";
+import getDataByPath from "../../../../../front-app/src/js/functions/getDataByPath";
+import PostsComponent from "../altrp-posts/altrp-posts";
+import RootComponentContext from "../../Contexts/RootComponentContext";
+
+class CardsWidget extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      settings: props.element.getSettings(),
+    };
+    props.element.component = this;
+    if (window.elementDecorator) {
+      window.elementDecorator(this);
+    }
+    if (props.baseRender) {
+      this.render = props.baseRender(this);
+    }
+    console.count('<<<<<< CardsWidget >>>>>>');
+  }
+
+  /**
+   * Показывать ли записи
+   * @param{Query} query
+   * @return {boolean}
+   */
+  showPosts(query = {}) {
+    if (
+      this.props.element.getLockedSettings("choose_datasource") === "datasource"
+    ) {
+      return true;
+    }
+    if (!query.modelName && !query.dataSource) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Получить css классы для posts widget ( cards widget )
+   */
+  getClasses = () => {
+    let classes = ``;
+    if (this.isActive()) {
+      classes += "active ";
+    }
+    if (this.isDisabled()) {
+      classes += "state-disabled ";
+    }
+    return classes;
+  };
+
+  render() {
+    let classes =
+      this.getClasses() +
+      (this.props.element.getResponsiveLockedSetting(
+        "position_css_classes",
+        "",
+        ""
+      ) || "");
+    if (!this.props.currentModel.getProperty("altrpModelUpdated")) {
+      return "";
+    }
+    let query = new Query(
+      this.props.element.getSettings().table_query || {},
+      this
+    );
+    if (!this.showPosts(query)) {
+      return <div children="Please Choose Source" />;
+    }
+    let data = query.getFromModel(this.state.modelData) || [];
+    if (
+      this.props.element.getLockedSettings("choose_datasource") === "datasource"
+    ) {
+      let path = this.props.element.getLockedSettings("posts_datasource", "");
+      path = path.replace(/}}/g, "").replace(/{{/g, "");
+      data = getDataByPath(
+        path,
+        [],
+        this.props.element.getCurrentModel().getData()
+      );
+    }
+
+    const settings = {
+      ...this.props.element.settings,
+      ...(this.props.element.settingsLock || {}),
+    };
+    if (this.context.isImportantStylesModule) {
+      return "";
+    }
+    return (
+      <PostsComponent
+        query={query}
+        className={classes}
+        currentModel={this.props.currentModel}
+        data={data}
+        element={this.props.element}
+        settings={settings}
+        />
+    );
+  }
+
+  static contextType = RootComponentContext;
+}
+
+export default CardsWidget;

--- a/resources/modules/editor/src/js/components/widgets/CardsWidget.js
+++ b/resources/modules/editor/src/js/components/widgets/CardsWidget.js
@@ -16,7 +16,6 @@ class CardsWidget extends Component {
     if (props.baseRender) {
       this.render = props.baseRender(this);
     }
-    console.count('<<<<<< CardsWidget >>>>>>');
   }
 
   /**

--- a/resources/modules/editor/src/js/store/widgets/defaultState.js
+++ b/resources/modules/editor/src/js/store/widgets/defaultState.js
@@ -63,11 +63,13 @@ import Nav from "../../classes/elements/Nav";
 import Table from "../../classes/elements/Table";
 import Template from "../../classes/elements/Template";
 import Posts from "../../classes/elements/Posts";
+import Cards from "../../classes/elements/Cards";
 import Map from "../../classes/elements/Map";
 import Menu from "../../classes/elements/Menu";
 import MapConstructor from "../../classes/elements/MapConstructor";
 import Dashboards from "../../classes/elements/Dashboards";
 import PostsWidget from "../../components/widgets/PostsWidget";
+import CardsWidget from "../../components/widgets/CardsWidget";
 import Gallery from "../../classes/elements/Gallery";
 import Tour from "../../classes/elements/Tour";
 import TourGuide from "../../components/widgets/TourGuide";
@@ -97,7 +99,7 @@ import InputMultiSelect from "../../classes/elements/InputMultiSelect";
 import InputMultiSelectWidget from "../../components/widgets/InputMultiSelectWidget";
 import Scheduler from "../../classes/elements/Scheduler";
 import SchedulerWidget from "../../components/widgets/SchedulerWidget";
-import Icon from '../../classes/elements/Icon';
+import Icon from "../../classes/elements/Icon";
 import IconWidget from "../../components/widgets/IconWidget";
 import InputTextAutocomplete from "../../classes/elements/InputTextAutocomplete";
 import InputTextAutocompleteWidget from "../../components/widgets/InputTextAutocompleteWidget";
@@ -107,7 +109,7 @@ import InputSelectTree from "../../classes/elements/InputSelectTree";
 import InputSelectTreeWidget from "../../components/widgets/InputSelectTreeWidget";
 import InputDateRange from "../../classes/elements/InputDateRange";
 import InputDateRangeWidget from "../../components/widgets/InputDateRangeWidget";
-import InputCropImage from '../../classes/elements/InputCropImage';
+import InputCropImage from "../../classes/elements/InputCropImage";
 import InputCropImageWidget from "../../components/widgets/InputCropImageWidget";
 import PieDiagram from "../../classes/elements/diagrams/PieDiagram";
 import PieDiagramWidget from "../../components/widgets/diagrams/PieDiagramWidget";
@@ -131,8 +133,8 @@ import FeedbackWidget from "../../components/widgets/FeedbackWidget";
 import InputPagination from "../../classes/elements/InputPagination";
 import InputPaginationWidget from "../../components/widgets/InputPaginationWidget";
 
-const elements = {}
-const components = {}
+const elements = {};
+const components = {};
 
 // elements[Input.getName()] = Input;
 //список элементов
@@ -175,6 +177,7 @@ elements[InputPagination.getName()] = InputPagination;
 
 elements[Table.getName()] = Table;
 elements[Posts.getName()] = Posts;
+elements[Cards.getName()] = Cards;
 elements[Gallery.getName()] = Gallery;
 elements[Carousel.getName()] = Carousel;
 elements[Map.getName()] = Map;
@@ -195,7 +198,7 @@ elements[LineDiagram.getName()] = LineDiagram;
 elements[FunnelDiagram.getName()] = FunnelDiagram;
 elements[RadarDiagram.getName()] = RadarDiagram;
 
-elements[Tournament.getName()] = Tournament
+elements[Tournament.getName()] = Tournament;
 elements[Feedback.getName()] = Feedback;
 elements[Column.getName()] = Column;
 elements[Section.getName()] = Section;
@@ -244,6 +247,7 @@ components[Text.getName()] = TextWidget;
 components[Image.getName()] = ImageWidget;
 components[Table.getName()] = TableWidget;
 components[Posts.getName()] = PostsWidget;
+components[Cards.getName()] = CardsWidget;
 components[Nav.getName()] = NavWidget;
 components[Divider.getName()] = DividerWidget;
 components[Tabs.getName()] = TabsWidget;
@@ -278,20 +282,20 @@ components[Tree.getName()] = TreeWidget;
 components[Icon.getName()] = IconWidget;
 components[Stars.getName()] = StarsWidget;
 components[ProgressBar.getName()] = ProgressBarWidget;
-components[Tournament.getName()] = TournamentWidget
-components[Feedback.getName()] = FeedbackWidget
+components[Tournament.getName()] = TournamentWidget;
+components[Feedback.getName()] = FeedbackWidget;
 
 export default {
-    elements: {
-        ...elements
-    },
-    components: {
-        ...components
-    },
-    allElements: {
-        ...elements
-    },
-    allComponents: {
-        ...components
-    }
-}
+  elements: {
+    ...elements,
+  },
+  components: {
+    ...components,
+  },
+  allElements: {
+    ...elements,
+  },
+  allComponents: {
+    ...components,
+  },
+};

--- a/resources/modules/front-app/src/js/store/front-elements-store/defaultState.js
+++ b/resources/modules/front-app/src/js/store/front-elements-store/defaultState.js
@@ -217,6 +217,12 @@ export const defaultState = [
     }
   },
   {
+    name: "cards",
+    import: async () => {
+      return await import(/* webpackChunkName: 'CostsWidget' */ "../../../../../editor/src/js/components/widgets/CardsWidget");
+    }
+  },
+  {
     name: "nav",
     import: async () => {
       return await import(/* webpackChunkName: 'NavWidget' */ "../../../../../editor/src/js/components/widgets/NavWidget");

--- a/server/classes/modules/FrontElementsManager.js
+++ b/server/classes/modules/FrontElementsManager.js
@@ -1,74 +1,74 @@
-import RootComponent from '../../../resources/modules/editor/src/js/components/RootComponent';
-import SectionComponent from '../../../resources/modules/editor/src/js/components/SectionComponent';
-import ColumnComponent from '../../../resources/modules/editor/src/js/components/ColumnComponent';
+import RootComponent from "../../../resources/modules/editor/src/js/components/RootComponent";
+import SectionComponent from "../../../resources/modules/editor/src/js/components/SectionComponent";
+import ColumnComponent from "../../../resources/modules/editor/src/js/components/ColumnComponent";
 // import InputWidget from '../../../resources/modules/editor/src/js/components/widgets/InputWidget';
-import ButtonWidget from '../../../resources/modules/editor/src/js/components/widgets/ButtonWidget';
-import TextWidget from '../../../resources/modules/editor/src/js/components/widgets/TextWidget';
-import ImageWidget from '../../../resources/modules/editor/src/js/components/widgets/ImageWidget';
+import ButtonWidget from "../../../resources/modules/editor/src/js/components/widgets/ButtonWidget";
+import TextWidget from "../../../resources/modules/editor/src/js/components/widgets/TextWidget";
+import ImageWidget from "../../../resources/modules/editor/src/js/components/widgets/ImageWidget";
 // import NavWidget from '../../../resources/modules/editor/src/js/components/widgets/NavWidget';
-import DividerWidget from '../../../resources/modules/editor/src/js/components/widgets/DividerWidget';
-import PosterWidget from '../../../resources/modules/editor/src/js/components/widgets/PosterWidget';
-import ListWidget from '../../../resources/modules/editor/src/js/components/widgets/ListWidget';
-import AccordionWidget from '../../../resources/modules/editor/src/js/components/widgets/AccordionWidget/AccordionWidget';
-import CarouselWidget from '../../../resources/modules/editor/src/js/components/widgets/CarouselWidget';
+import DividerWidget from "../../../resources/modules/editor/src/js/components/widgets/DividerWidget";
+import PosterWidget from "../../../resources/modules/editor/src/js/components/widgets/PosterWidget";
+import ListWidget from "../../../resources/modules/editor/src/js/components/widgets/ListWidget";
+import AccordionWidget from "../../../resources/modules/editor/src/js/components/widgets/AccordionWidget/AccordionWidget";
+import CarouselWidget from "../../../resources/modules/editor/src/js/components/widgets/CarouselWidget";
 // import MapWidget from '../../../resources/modules/editor/src/js/components/widgets/MapWidget';
 // import MapConstructorWidget from '../../../resources/modules/editor/src/js/components/widgets/MapConstructorWidget';
 // import DiagramWidget from '../../../resources/modules/editor/src/js/components/widgets/DiagramWidget';
 // import DashboardsWidget from '../../../resources/modules/editor/src/js/components/widgets/DashboardsWidget';
-import PostsWidget from '../../../resources/modules/editor/src/js/components/widgets/PostsWidget';
+import PostsWidget from "../../../resources/modules/editor/src/js/components/widgets/PostsWidget";
+import CardsWidget from "../../../resources/modules/editor/src/js/components/widgets/CardsWidget";
 // import IconWidget from '../../../resources/modules/editor/src/js/components/widgets/IconWidget';
 // import TourGuide from '../../../resources/modules/editor/src/js/components/widgets/TourGuide';
 // import ExportPanelWindget from '../../../resources/modules/editor/src/js/components/widgets/ExportPanelWidget';
-import HtmlWidget from '../../../resources/modules/editor/src/js/components/widgets/HtmlWidget';
+import HtmlWidget from "../../../resources/modules/editor/src/js/components/widgets/HtmlWidget";
 // import TemplateWidget from '../../../resources/modules/editor/src/js/components/widgets/TemplateWidget';
 // import GalleryWidget from '../../../resources/modules/editor/src/js/components/widgets/GalleryWidget';
-import VideoWidget from '../../../resources/modules/editor/src/js/components/widgets/VideoWidget';
+import VideoWidget from "../../../resources/modules/editor/src/js/components/widgets/VideoWidget";
 // import Skeleton from '../../../resources/modules/editor/src/js/components/altrp-image/Skeleton';
-import SkeletonPlaceholder from '../components/SkeletonPlaceholder';
-import HeadingTypeHeadingWidget
-  from "../../../resources/modules/editor/src/js/components/widgets/HeadingTypeHeadingWidget";
+import SkeletonPlaceholder from "../components/SkeletonPlaceholder";
+import HeadingTypeHeadingWidget from "../../../resources/modules/editor/src/js/components/widgets/HeadingTypeHeadingWidget";
 import SKELETON_ELEMENTS from "../../../resources/modules/front-app/src/js/constants/SKELETON_ELEMENTS";
 import InputHiddenWidget from "../../../resources/modules/editor/src/js/components/widgets/InputHiddenWidget";
 import TemplateWidget from "../../../resources/modules/editor/src/js/components/widgets/TemplateWidget";
 import ImageLightboxWidget from "../../../resources/modules/editor/src/js/components/widgets/ImageLightboxWidget";
-import IconWidget from "../../../resources/modules/editor/src/js/components/widgets/IconWidget"
+import IconWidget from "../../../resources/modules/editor/src/js/components/widgets/IconWidget";
 import MenuPlaceholder from "../components/MenuPlaceholder/MenuPlaceholder";
 import ActionTriggerWidget from "../../../resources/modules/editor/src/js/components/widgets/ActionTriggerWidget";
 // import BreadcrumbsWidget from '../../../resources/modules/editor/src/js/components/widgets/BreadcrumbsWidget';
 // import MenuWidget from '../../../resources/modules/editor/src/js/components/widgets/MenuWidget';
 
-
 class FrontElementsManager {
   constructor() {
     //список компонентов
     this.components = {};
-    SKELETON_ELEMENTS.forEach(el=>{
-      if(el === "menu") {
+    SKELETON_ELEMENTS.forEach((el) => {
+      if (el === "menu") {
         this.components[el] = MenuPlaceholder;
       } else {
         this.components[el] = SkeletonPlaceholder;
       }
-    })
-    this.components['root-element'] = RootComponent;
-    this.components['action-trigger'] = ActionTriggerWidget
-    this.components['heading'] = HeadingTypeHeadingWidget;
-    this.components['section'] = SectionComponent;
-    this.components['section_widget'] = SectionComponent;
-    this.components['column'] = ColumnComponent;
-    this.components['button'] = ButtonWidget;
-    this.components['input-hidden'] = InputHiddenWidget;
-    this.components['text'] = TextWidget;
-    this.components['text-common'] = TextWidget;
-    this.components['image'] = ImageWidget;
-    this.components['image-lightbox'] = ImageLightboxWidget;
-    this.components['posts'] = PostsWidget;
-    this.components['divider'] = DividerWidget;
-    this.components['poster'] = PosterWidget;
-    this.components['list'] = ListWidget;
-    this.components['accordion'] = AccordionWidget;
-    this.components['html'] = HtmlWidget;
-    this.components['video'] = VideoWidget;
-    this.components['template'] = TemplateWidget;
+    });
+    this.components["root-element"] = RootComponent;
+    this.components["action-trigger"] = ActionTriggerWidget;
+    this.components["heading"] = HeadingTypeHeadingWidget;
+    this.components["section"] = SectionComponent;
+    this.components["section_widget"] = SectionComponent;
+    this.components["column"] = ColumnComponent;
+    this.components["button"] = ButtonWidget;
+    this.components["input-hidden"] = InputHiddenWidget;
+    this.components["text"] = TextWidget;
+    this.components["text-common"] = TextWidget;
+    this.components["image"] = ImageWidget;
+    this.components["image-lightbox"] = ImageLightboxWidget;
+    this.components["posts"] = PostsWidget;
+    this.components["cards"] = CardsWidget;
+    this.components["divider"] = DividerWidget;
+    this.components["poster"] = PosterWidget;
+    this.components["list"] = ListWidget;
+    this.components["accordion"] = AccordionWidget;
+    this.components["html"] = HtmlWidget;
+    this.components["video"] = VideoWidget;
+    this.components["template"] = TemplateWidget;
     // this.components['icon'] = IconWidget;
   }
 
@@ -78,8 +78,8 @@ class FrontElementsManager {
    * @returns {(function(*): *)|*}
    */
   getComponentClass(name) {
-    if (! this.components[name]) {
-      return SkeletonPlaceholder
+    if (!this.components[name]) {
+      return SkeletonPlaceholder;
     }
     return this.components[name];
   }
@@ -89,4 +89,3 @@ class FrontElementsManager {
   }
 }
 export default window.frontElementsManager = new FrontElementsManager();
-

--- a/webpack.editor.dev.js
+++ b/webpack.editor.dev.js
@@ -1,14 +1,15 @@
 const path = require("path");
-const merge = require('webpack-merge');
-const common = require('./webpack.editor.common.js');
-const fs = require('fs');
-const http = require('http');
+const merge = require("webpack-merge");
+const common = require("./webpack.editor.common.js");
+const fs = require("fs");
+const http = require("http");
 
 module.exports = merge(common, {
-  mode: 'development',
-  devtool: 'inline-source-map',
+  mode: "development",
+  devtool: "inline-source-map",
 
   devServer: {
+    host: "127.0.0.1", // Without this string, the editor will not work in specific cases
     disableHostCheck: true,
     contentBase: path.join(__dirname, "resources/modules/editor/public/"),
     port: 3000,


### PR DESCRIPTION
**What is done:**

The new SSR component (Cards) is added:
<img width="1920" height="875" alt="image" src="https://github.com/user-attachments/assets/270f862d-90b9-4dac-9c8b-b60c02d4c52a" />

The old SPA component (Posts) is still remaining for convinience. When Cards component is ready, it will be renamed to Posts component. The old Posts component will be removed.

You can now add the new Cards widget from the editor. It's called "new Cards":
<img width="1920" height="874" alt="image" src="https://github.com/user-attachments/assets/a162bacb-7ff1-4fa6-bc5c-0a8eacaf5ddb" />

**renderCards.rs** widget receives the child template and parses children, adding widget's ID and index to the template strings.

**AlterpRouting.ts** recursively collects all datasources from Card's chidlren, renames template strings, using the widget's ID and element's index. Passes them to the Mustache renderer. Necessary data replace coresponding template strings. Then HTML sends to the frontend.

**What still needs to be done:**

- Finish all varients of pagination element
- Hydrate HTML on the frontend
- Remove the old Posts widget, rename the new Cards widget